### PR TITLE
Add Vector Types

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -8,7 +8,7 @@ use crate::blaslapack::getrf::Getrf;
 //{{{ std imports
 use ::std::ops::{Add, Div, Mul, Neg, Sub};
 use std::cmp::PartialEq;
-use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign, Index, IndexMut};
+use std::ops::{AddAssign, DivAssign, Index, IndexMut, MulAssign, SubAssign};
 
 //}}}
 //{{{ dep imports
@@ -200,7 +200,7 @@ pub trait Float: Field
     ) -> Self;
 }
 //}}}
-//{{{ impl: Float for f32 
+//{{{ impl: Float for f32
 impl Float for f32
 {
     fn acos(self) -> Self
@@ -272,7 +272,7 @@ where
     fn trace(&self) -> Self::ScalarType;
 }
 //}}}
-//{{{ trait: VectorOps 
+//{{{ trait: VectorOps
 pub trait VectorOps:
     Index<usize, Output = Self::ScalarType> + IndexMut<usize, Output = Self::ScalarType> + Sized + Clone
 {
@@ -344,7 +344,7 @@ pub trait VectorOps:
             panic!("Cross product is only defined for 2D and 3D vectors");
         }
 
-        if self.len() != other.len() 
+        if self.len() != other.len()
         {
             panic!("Vectors must be of the same length");
         }
@@ -369,8 +369,7 @@ where
         other: &Self,
     ) -> Self::ScalarType
     {
-
-        if self.len() != other.len() 
+        if self.len() != other.len()
         {
             panic!("Vectors must be of the same length");
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -305,6 +305,11 @@ pub trait VectorOps:
         other: &Self,
     ) -> Self::ScalarType
     {
+        if self.len() != other.len()
+        {
+            panic!("Vectors must be of the same length");
+        }
+
         let mut out = Self::ScalarType::zero();
         for i in 0..self.len()
         {
@@ -337,6 +342,11 @@ pub trait VectorOps:
         if self.len() != 3
         {
             panic!("Cross product is only defined for 2D and 3D vectors");
+        }
+
+        if self.len() != other.len() 
+        {
+            panic!("Vectors must be of the same length");
         }
 
         let mut out = other.clone();

--- a/src/common.rs
+++ b/src/common.rs
@@ -359,6 +359,17 @@ where
         other: &Self,
     ) -> Self::ScalarType
     {
+
+        if self.len() != other.len() 
+        {
+            panic!("Vectors must be of the same length");
+        }
+
+        if self.len() != 2 && self.len() != 3
+        {
+            panic!("Angle is only defined for 2D and 3D vectors");
+        }
+
         if self.norm() < Self::ScalarType::small() || other.norm() < Self::ScalarType::small()
         {
             panic!("Cannot compute angle with zero vector");

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,7 +8,7 @@ use crate::blaslapack::getrf::Getrf;
 //{{{ std imports
 use ::std::ops::{Add, Div, Mul, Neg, Sub};
 use std::cmp::PartialEq;
-use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign, Index, IndexMut};
 
 //}}}
 //{{{ dep imports
@@ -151,7 +151,6 @@ pub trait One
 }
 //}}}
 //{{{ collection: impl_one implementations
-
 impl One for f32
 {
     fn one() -> Self
@@ -185,7 +184,7 @@ apply_for_all_integer_types!(impl_zero);
 //{{{ collection: re-exports
 pub use num_complex::Complex;
 //}}}
-
+//{{{ trait: Float
 pub trait Float: Field
 {
     fn acos(self) -> Self;
@@ -200,6 +199,8 @@ pub trait Float: Field
         exp: i32,
     ) -> Self;
 }
+//}}}
+//{{{ impl: Float for f32 
 impl Float for f32
 {
     fn acos(self) -> Self
@@ -226,6 +227,8 @@ impl Float for f32
         self.powi(exp)
     }
 }
+//}}}
+//{{{ impl: Float for f64
 impl Float for f64
 {
     fn acos(self) -> Self
@@ -252,7 +255,8 @@ impl Float for f64
         self.powi(exp)
     }
 }
-
+//}}}
+//{{{ trait: MatrixOps
 pub trait MatrixOps
 where
     Self: Sized,
@@ -267,3 +271,104 @@ where
         Self::ScalarType: Getrf + Float;
     fn trace(&self) -> Self::ScalarType;
 }
+//}}}
+//{{{ trait: VectorOps 
+pub trait VectorOps:
+    Index<usize, Output = Self::ScalarType> + IndexMut<usize, Output = Self::ScalarType> + Sized + Clone
+{
+    type ScalarType: Field + Zero + One + Copy + Default;
+
+    //{{{ fn: len
+    fn len(&self) -> usize;
+    //}}}
+    //{{{ fn: norm
+    /// Computes the norm (magnitude) of the vector.
+    ///
+    /// # Returns
+    ///
+    /// The norm of the vector as a value of type `Self::T`.
+    ///
+    fn norm(&self) -> Self::ScalarType
+    {
+        let mut out = Self::ScalarType::zero();
+
+        for i in 0..self.len()
+        {
+            out += self[i] * self[i]
+        }
+        out
+    }
+    //}}}
+    //{{{ fn: dot
+    fn dot(
+        &self,
+        other: &Self,
+    ) -> Self::ScalarType
+    {
+        let mut out = Self::ScalarType::zero();
+        for i in 0..self.len()
+        {
+            out += self[i] * other[i]
+        }
+        out
+    }
+    //}}}
+    //{{{ fn: normalize
+    fn normalize(&self) -> Self
+    {
+        let norm = self.norm();
+        let mut out = self.clone();
+        if norm != Self::ScalarType::zero()
+        {
+            for i in 0..self.len()
+            {
+                out[i] /= norm;
+            }
+        }
+        out
+    }
+    //}}}
+    //{{{ fn: cross
+    fn cross(
+        &self,
+        other: &Self,
+    ) -> Self
+    {
+        if self.len() != 3
+        {
+            panic!("Cross product is only defined for 2D and 3D vectors");
+        }
+
+        let mut out = other.clone();
+        out[0] = self[1] * other[2] - self[2] * other[1];
+        out[1] = self[2] * other[0] - self[0] * other[2];
+        out[2] = self[0] * other[1] - self[1] * other[0];
+        out
+    }
+    //}}}
+}
+//}}}
+//{{{ trait: FloatVectorOps
+pub trait FloatVectorOps: VectorOps
+where
+    Self::ScalarType: Float + Zero + One + Copy + Default,
+{
+    //{{{ fn: angle
+    fn angle(
+        &self,
+        other: &Self,
+    ) -> Self::ScalarType
+    {
+        if self.norm() < Self::ScalarType::small() || other.norm() < Self::ScalarType::small()
+        {
+            panic!("Cannot compute angle with zero vector");
+        }
+
+        let a = self.normalize();
+        let b = other.normalize();
+        let dot = (a.dot(&b)).clamp(-Self::ScalarType::one(), Self::ScalarType::one());
+        dot.acos()
+    }
+    //}}}
+}
+//}}}

--- a/src/common.rs
+++ b/src/common.rs
@@ -273,6 +273,7 @@ where
 }
 //}}}
 //{{{ trait: VectorOps
+#[allow(clippy::len_without_is_empty)]
 pub trait VectorOps:
     Index<usize, Output = Self::ScalarType> + IndexMut<usize, Output = Self::ScalarType> + Sized + Clone
 {

--- a/src/dvector/mod.rs
+++ b/src/dvector/mod.rs
@@ -3,21 +3,21 @@
 //! Longer description of module
 //--------------------------------------------------------------------------------------------------
 
-//{{{ crate imports 
+//{{{ crate imports
+use crate::common::{Field, Float, FloatVectorOps, One, VectorOps, Zero};
 use crate::dmatrix::DMatrix;
-use crate::common::{Field, One, Zero, VectorOps, FloatVectorOps, Float};
 //}}}
-//{{{ std imports 
+//{{{ std imports
 //}}}
-//{{{ dep imports 
+//{{{ dep imports
 use rand::distributions::uniform::SampleUniform;
 //}}}
 //--------------------------------------------------------------------------------------------------
 
-
 pub type DVector<T> = DMatrix<T>;
 
-pub enum VecType {
+pub enum VecType
+{
     Row,
     Col,
 }
@@ -33,7 +33,8 @@ where
         vec_type: VecType,
     ) -> Self
     {
-        match vec_type {
+        match vec_type
+        {
             VecType::Row => Self::from_value(value, 1, nelem),
             VecType::Col => Self::from_value(value, nelem, 1),
         }
@@ -47,7 +48,8 @@ where
     where
         T: Zero,
     {
-        match vec_type {
+        match vec_type
+        {
             VecType::Row => Self::zeros(1, nelem),
             VecType::Col => Self::zeros(nelem, 1),
         }
@@ -61,7 +63,8 @@ where
     where
         T: One,
     {
-        match vec_type {
+        match vec_type
+        {
             VecType::Row => Self::ones(1, nelem),
             VecType::Col => Self::ones(nelem, 1),
         }
@@ -72,25 +75,27 @@ where
         nelem: usize,
         vec_type: VecType,
     ) -> Self
-    where 
-        T: Zero
+    where
+        T: Zero,
     {
-        match vec_type {
+        match vec_type
+        {
             VecType::Row => Self::from_col_slice(slice, 1, nelem),
             VecType::Col => Self::from_col_slice(slice, nelem, 1),
         }
     }
 
     pub fn from_uniform_random_cvec(
-        low: T, 
-        high: T, 
-        nelem: usize, 
+        low: T,
+        high: T,
+        nelem: usize,
         vec_type: VecType,
     ) -> Self
     where
         T: SampleUniform + Field + Copy + Zero,
     {
-        match vec_type {
+        match vec_type
+        {
             VecType::Row => Self::from_uniform_random(low, high, 1, nelem),
             VecType::Col => Self::from_uniform_random(low, high, nelem, 1),
         }
@@ -105,21 +110,20 @@ where
 
     fn len(&self) -> usize
     {
-        if self.nrows != 1 && self.ncols != 1 {
+        if self.nrows != 1 && self.ncols != 1
+        {
             panic!("Vector must be either a row or column vector");
         }
 
-        if self.nrows == 1 {
+        if self.nrows == 1
+        {
             self.ncols
-        } else {
+        }
+        else
+        {
             self.nrows
         }
     }
 }
 
-impl<T> FloatVectorOps for DVector<T>
-where 
-    T: Float + Default + Copy + Clone + Zero + One,
-{
-
-}
+impl<T> FloatVectorOps for DVector<T> where T: Float + Default + Copy + Clone + Zero + One {}

--- a/src/dvector/mod.rs
+++ b/src/dvector/mod.rs
@@ -1,0 +1,128 @@
+//! Short Description of module
+//!
+//! Longer description of module
+//--------------------------------------------------------------------------------------------------
+
+
+use std::vec;
+
+//{{{ crate imports 
+use crate::dmatrix::DMatrix;
+use crate::common::{Field, One, Zero, VectorOps, FloatVectorOps, Float};
+//}}}
+//{{{ std imports 
+//}}}
+//{{{ dep imports 
+use rand::distributions::uniform::SampleUniform;
+//}}}
+//--------------------------------------------------------------------------------------------------
+
+
+pub type DVector<T> = DMatrix<T>;
+
+pub enum VecType {
+    Row,
+    Col,
+}
+
+impl<T> DVector<T>
+where
+    T: Field + Copy,
+{
+    /// Creates a new `DVector` initialized with the given value.
+    pub fn from_value_vec(
+        value: T,
+        nelem: usize,
+        vec_type: VecType,
+    ) -> Self
+    {
+        match vec_type {
+            VecType::Row => Self::from_value(value, 1, nelem),
+            VecType::Col => Self::from_value(value, nelem, 1),
+        }
+    }
+
+    /// Creates a new `DVector` initialized with zeros.
+    pub fn zeros_cvec(
+        nelem: usize,
+        vec_type: VecType,
+    ) -> Self
+    where
+        T: Zero,
+    {
+        match vec_type {
+            VecType::Row => Self::zeros(1, nelem),
+            VecType::Col => Self::zeros(nelem, 1),
+        }
+    }
+
+    /// Creates a new `DVector` initialized with ones.
+    pub fn ones_cvec(
+        nelem: usize,
+        vec_type: VecType,
+    ) -> Self
+    where
+        T: One,
+    {
+        match vec_type {
+            VecType::Row => Self::ones(1, nelem),
+            VecType::Col => Self::ones(nelem, 1),
+        }
+    }
+
+    pub fn from_slice_vec(
+        slice: &[T],
+        nelem: usize,
+        vec_type: VecType,
+    ) -> Self
+    where 
+        T: Zero
+    {
+        match vec_type {
+            VecType::Row => Self::from_col_slice(slice, 1, nelem),
+            VecType::Col => Self::from_col_slice(slice, nelem, 1),
+        }
+    }
+
+    pub fn from_uniform_random_cvec(
+        low: T, 
+        high: T, 
+        nelem: usize, 
+        vec_type: VecType,
+    ) -> Self
+    where
+        T: SampleUniform + Field + Copy + Zero,
+    {
+        match vec_type {
+            VecType::Row => Self::from_uniform_random(low, high, 1, nelem),
+            VecType::Col => Self::from_uniform_random(low, high, nelem, 1),
+        }
+    }
+}
+
+impl<T> VectorOps for DVector<T>
+where
+    T: Field + Default + Copy + Clone + Zero + One,
+{
+    type ScalarType = T;
+
+    fn len(&self) -> usize
+    {
+        if self.nrows != 1 && self.ncols != 1 {
+            panic!("Vector must be either a row or column vector");
+        }
+
+        if self.nrows == 1 {
+            self.ncols
+        } else {
+            self.nrows
+        }
+    }
+}
+
+impl<T> FloatVectorOps for DVector<T>
+where 
+    T: Float + Default + Copy + Clone + Zero + One,
+{
+
+}

--- a/src/dvector/mod.rs
+++ b/src/dvector/mod.rs
@@ -3,9 +3,6 @@
 //! Longer description of module
 //--------------------------------------------------------------------------------------------------
 
-
-use std::vec;
-
 //{{{ crate imports 
 use crate::dmatrix::DMatrix;
 use crate::common::{Field, One, Zero, VectorOps, FloatVectorOps, Float};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod expression;
 //{{{ collection: public API
 pub use common::{Complex, MatrixOps, VectorOps, FloatVectorOps};
 pub mod dmatrix;
+pub mod dvector;
 pub mod smatrix;
 pub mod srvector;
 pub mod scvector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! Short Description of module
+//! # Welcome to Topohedral-Linalg!
 //!
-//! Longer description of module
+//! 
 //--------------------------------------------------------------------------------------------------
 
 //{{{ crate imports
@@ -20,9 +20,11 @@ mod common;
 mod expression;
 //}}}
 //{{{ collection: public API
-pub use common::{Complex, MatrixOps};
+pub use common::{Complex, MatrixOps, VectorOps, FloatVectorOps};
 pub mod dmatrix;
 pub mod smatrix;
+pub mod srvector;
+pub mod scvector;
 //}}}
 
 //-------------------------------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Welcome to Topohedral-Linalg!
 //!
-//! 
+//!
 //--------------------------------------------------------------------------------------------------
 
 //{{{ crate imports
@@ -20,12 +20,12 @@ mod common;
 mod expression;
 //}}}
 //{{{ collection: public API
-pub use common::{Complex, MatrixOps, VectorOps, FloatVectorOps};
+pub use common::{Complex, FloatVectorOps, MatrixOps, VectorOps};
 pub mod dmatrix;
 pub mod dvector;
+pub mod scvector;
 pub mod smatrix;
 pub mod srvector;
-pub mod scvector;
 //}}}
 
 //-------------------------------------------------------------------------------------------------

--- a/src/scvector/mod.rs
+++ b/src/scvector/mod.rs
@@ -1,0 +1,51 @@
+//! Provides a statically-sized column vector type
+//!
+//--------------------------------------------------------------------------------------------------
+
+//{{{ crate imports 
+use super::smatrix::SMatrix;
+use crate::common::{VectorOps, FloatVectorOps, Zero, One, Field, Float};
+//}}}
+//{{{ std imports 
+//}}}
+//{{{ dep imports 
+//}}}
+//--------------------------------------------------------------------------------------------------
+
+//{{{ collection: compile-time checks
+/// Assertion struct for compile-time checks
+struct Assert<const check: bool>;
+/// This trait is used to ensure that the compile-time check is true
+trait IsTrue {}
+impl IsTrue for Assert<true> {}
+//}}}
+//{{{ type: SCVector
+/// A type alias for a column vector of size N.
+pub type SCVector<T, const N: usize> = SMatrix<T, N, 1>;
+//}}}
+//{{{ impl: VectorOps for SCVector
+impl<T, const N: usize>  VectorOps for SCVector<T, N>
+where
+    [(); N * 1]:,
+    T: Field + Default + Copy + Clone + Zero + One,
+    Assert<{N > 1}>: IsTrue,
+{
+
+    type ScalarType = T;
+
+    fn len(&self) -> usize
+    {
+        N
+    }
+}
+//}}}
+//{{{ impl: FloatVectorOps for SCVector
+impl<T, const N: usize> FloatVectorOps for SCVector<T, N> 
+where
+    [(); N * 1]:,
+    T: Float + Default + Copy + Clone + Zero + One,
+    Assert<{N > 1}>: IsTrue,
+{}
+//}}}
+
+

--- a/src/scvector/mod.rs
+++ b/src/scvector/mod.rs
@@ -14,7 +14,7 @@ use crate::common::{VectorOps, FloatVectorOps, Zero, One, Field, Float};
 
 //{{{ collection: compile-time checks
 /// Assertion struct for compile-time checks
-struct Assert<const check: bool>;
+struct Assert<const CHECK: bool>;
 /// This trait is used to ensure that the compile-time check is true
 trait IsTrue {}
 impl IsTrue for Assert<true> {}

--- a/src/scvector/mod.rs
+++ b/src/scvector/mod.rs
@@ -24,6 +24,7 @@ impl IsTrue for Assert<true> {}
 pub type SCVector<T, const N: usize> = SMatrix<T, N, 1>;
 //}}}
 //{{{ impl: VectorOps for SCVector
+#[allow(clippy::identity_op)]
 impl<T, const N: usize> VectorOps for SCVector<T, N>
 where
     [(); N * 1]:,
@@ -39,6 +40,7 @@ where
 }
 //}}}
 //{{{ impl: FloatVectorOps for SCVector
+#[allow(clippy::identity_op)]
 impl<T, const N: usize> FloatVectorOps for SCVector<T, N>
 where
     [(); N * 1]:,

--- a/src/scvector/mod.rs
+++ b/src/scvector/mod.rs
@@ -2,13 +2,13 @@
 //!
 //--------------------------------------------------------------------------------------------------
 
-//{{{ crate imports 
+//{{{ crate imports
 use super::smatrix::SMatrix;
-use crate::common::{VectorOps, FloatVectorOps, Zero, One, Field, Float};
+use crate::common::{Field, Float, FloatVectorOps, One, VectorOps, Zero};
 //}}}
-//{{{ std imports 
+//{{{ std imports
 //}}}
-//{{{ dep imports 
+//{{{ dep imports
 //}}}
 //--------------------------------------------------------------------------------------------------
 
@@ -24,13 +24,12 @@ impl IsTrue for Assert<true> {}
 pub type SCVector<T, const N: usize> = SMatrix<T, N, 1>;
 //}}}
 //{{{ impl: VectorOps for SCVector
-impl<T, const N: usize>  VectorOps for SCVector<T, N>
+impl<T, const N: usize> VectorOps for SCVector<T, N>
 where
     [(); N * 1]:,
     T: Field + Default + Copy + Clone + Zero + One,
-    Assert<{N > 1}>: IsTrue,
+    Assert<{ N > 1 }>: IsTrue,
 {
-
     type ScalarType = T;
 
     fn len(&self) -> usize
@@ -40,12 +39,11 @@ where
 }
 //}}}
 //{{{ impl: FloatVectorOps for SCVector
-impl<T, const N: usize> FloatVectorOps for SCVector<T, N> 
+impl<T, const N: usize> FloatVectorOps for SCVector<T, N>
 where
     [(); N * 1]:,
     T: Float + Default + Copy + Clone + Zero + One,
-    Assert<{N > 1}>: IsTrue,
-{}
+    Assert<{ N > 1 }>: IsTrue,
+{
+}
 //}}}
-
-

--- a/src/srvector/mod.rs
+++ b/src/srvector/mod.rs
@@ -2,13 +2,13 @@
 //!
 //--------------------------------------------------------------------------------------------------
 
-//{{{ crate imports 
+//{{{ crate imports
 use super::smatrix::SMatrix;
-use crate::common::{VectorOps, FloatVectorOps, Zero, One, Field, Float};
+use crate::common::{Field, Float, FloatVectorOps, One, VectorOps, Zero};
 //}}}
-//{{{ std imports 
+//{{{ std imports
 //}}}
-//{{{ dep imports 
+//{{{ dep imports
 //}}}
 //--------------------------------------------------------------------------------------------------
 
@@ -24,13 +24,12 @@ impl IsTrue for Assert<true> {}
 pub type SRVector<T, const N: usize> = SMatrix<T, 1, N>;
 //}}}
 //{{{ impl: VectorOps for SCVector
-impl<T, const N: usize>  VectorOps for SRVector<T, N>
+impl<T, const N: usize> VectorOps for SRVector<T, N>
 where
     [(); 1usize * N]:,
     T: Field + Default + Copy + Clone + Zero + One,
-    Assert<{N > 1}>: IsTrue,
+    Assert<{ N > 1 }>: IsTrue,
 {
-
     type ScalarType = T;
 
     fn len(&self) -> usize
@@ -40,10 +39,11 @@ where
 }
 //}}}
 //{{{ impl: FloatVectorOps for SCVector
-impl<T, const N: usize> FloatVectorOps for SRVector<T, N> 
+impl<T, const N: usize> FloatVectorOps for SRVector<T, N>
 where
     [(); 1usize * N]:,
     T: Float + Default + Copy + Clone + Zero + One,
-    Assert<{N > 1}>: IsTrue,
-{}
+    Assert<{ N > 1 }>: IsTrue,
+{
+}
 //}}}

--- a/src/srvector/mod.rs
+++ b/src/srvector/mod.rs
@@ -1,0 +1,49 @@
+//! Provides a statically-sized column vector type
+//!
+//--------------------------------------------------------------------------------------------------
+
+//{{{ crate imports 
+use super::smatrix::SMatrix;
+use crate::common::{VectorOps, FloatVectorOps, Zero, One, Field, Float};
+//}}}
+//{{{ std imports 
+//}}}
+//{{{ dep imports 
+//}}}
+//--------------------------------------------------------------------------------------------------
+
+//{{{ collection: compile-time checks
+/// Assertion struct for compile-time checks
+struct Assert<const check: bool>;
+/// This trait is used to ensure that the compile-time check is true
+trait IsTrue {}
+impl IsTrue for Assert<true> {}
+//}}}
+//{{{ type: SCVector
+/// A type alias for a column vector of size N.
+pub type SRVector<T, const N: usize> = SMatrix<T, 1, N>;
+//}}}
+//{{{ impl: VectorOps for SCVector
+impl<T, const N: usize>  VectorOps for SRVector<T, N>
+where
+    [(); 1usize * N]:,
+    T: Field + Default + Copy + Clone + Zero + One,
+    Assert<{N > 1}>: IsTrue,
+{
+
+    type ScalarType = T;
+
+    fn len(&self) -> usize
+    {
+        N
+    }
+}
+//}}}
+//{{{ impl: FloatVectorOps for SCVector
+impl<T, const N: usize> FloatVectorOps for SRVector<T, N> 
+where
+    [(); 1usize * N]:,
+    T: Float + Default + Copy + Clone + Zero + One,
+    Assert<{N > 1}>: IsTrue,
+{}
+//}}}

--- a/src/srvector/mod.rs
+++ b/src/srvector/mod.rs
@@ -14,7 +14,7 @@ use crate::common::{VectorOps, FloatVectorOps, Zero, One, Field, Float};
 
 //{{{ collection: compile-time checks
 /// Assertion struct for compile-time checks
-struct Assert<const check: bool>;
+struct Assert<const CHECK: bool>;
 /// This trait is used to ensure that the compile-time check is true
 trait IsTrue {}
 impl IsTrue for Assert<true> {}

--- a/src/srvector/mod.rs
+++ b/src/srvector/mod.rs
@@ -24,6 +24,7 @@ impl IsTrue for Assert<true> {}
 pub type SRVector<T, const N: usize> = SMatrix<T, 1, N>;
 //}}}
 //{{{ impl: VectorOps for SCVector
+#[allow(clippy::identity_op)]
 impl<T, const N: usize> VectorOps for SRVector<T, N>
 where
     [(); 1usize * N]:,
@@ -39,6 +40,7 @@ where
 }
 //}}}
 //{{{ impl: FloatVectorOps for SCVector
+#[allow(clippy::identity_op)]
 impl<T, const N: usize> FloatVectorOps for SRVector<T, N>
 where
     [(); 1usize * N]:,

--- a/tests/vector_ops.rs
+++ b/tests/vector_ops.rs
@@ -120,7 +120,6 @@ mod srvector_tests
 mod dvector_tests 
 {
     use approx::assert_relative_eq;
-    use topohedral_linalg::dmatrix::DMatrix;
     use topohedral_linalg::dvector::{DVector, VecType};
     use topohedral_linalg::{VectorOps, FloatVectorOps};
 

--- a/tests/vector_ops.rs
+++ b/tests/vector_ops.rs
@@ -60,3 +60,60 @@ mod scvector_tests
     }
 
 }
+
+mod srvector_tests 
+{
+
+    use approx::assert_relative_eq;
+    use topohedral_linalg::srvector::SRVector;
+    use topohedral_linalg::{VectorOps, FloatVectorOps};
+
+    #[test]
+    fn test_norm()
+    {
+        let v = SRVector::<f64, 3>::from_row_slice(&[1.0, 2.0, 3.0]);
+        let norm = v.norm();
+        assert_relative_eq!(norm, 14.0);
+    }
+
+    #[test]
+    fn test_dot()
+    {
+        let v1 = SRVector::<f64, 3>::from_row_slice(&[1.0, 2.0, 3.0]);
+        let v2 = SRVector::<f64, 3>::from_row_slice(&[4.0, 5.0, 6.0]);
+        let dot = v1.dot(&v2);
+        assert_relative_eq!(dot, 32.0);
+    }
+
+    #[test]
+    fn test_normalize()
+    {
+        let v = SRVector::<f64, 3>::from_row_slice(&[1.0, 2.0, 3.0]);
+        let norm = v.norm();
+        let normalized = v.normalize();
+        assert_relative_eq!(normalized[0], 1.0 / norm);
+        assert_relative_eq!(normalized[1], 2.0 / norm);
+        assert_relative_eq!(normalized[2], 3.0 / norm);
+    }
+
+    #[test]
+    fn test_cross()
+    {
+        let v1 = SRVector::<f64, 3>::from_row_slice(&[1.0, 2.0, 3.0]);
+        let v2 = SRVector::<f64, 3>::from_row_slice(&[4.0, 5.0, 6.0]);
+        let cross = v1.cross(&v2);
+        assert_relative_eq!(cross[0], -3.0);
+        assert_relative_eq!(cross[1], 6.0);
+        assert_relative_eq!(cross[2], -3.0);
+    }
+
+    #[test]
+    fn test_angle() {
+        let v1 = SRVector::<f64, 3>::from_row_slice(&[1.0, 0.0, 0.0]);
+        let v2 = SRVector::<f64, 3>::from_row_slice(&[0.0, 1.0, 0.0]);
+        let angle1 = v1.angle(&v2);
+        assert_relative_eq!(angle1, std::f64::consts::FRAC_PI_2);
+        let angle2 = v2.angle(&v1);
+        assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
+    }
+}

--- a/tests/vector_ops.rs
+++ b/tests/vector_ops.rs
@@ -117,3 +117,96 @@ mod srvector_tests
         assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
     }
 }
+mod dvector_tests 
+{
+    use approx::assert_relative_eq;
+    use topohedral_linalg::dmatrix::DMatrix;
+    use topohedral_linalg::dvector::{DVector, VecType};
+    use topohedral_linalg::{VectorOps, FloatVectorOps};
+
+    #[test]
+    fn test_norm()
+    {
+        {
+        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+        let norm = v.norm();
+        assert_relative_eq!(norm, 14.0);
+        }
+        {
+        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+        let norm = v.norm();
+        assert_relative_eq!(norm, 14.0);
+        }
+    }
+
+    #[test]
+    fn test_dot()
+    {
+        {
+        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Row);
+        let dot = v1.dot(&v2);
+        assert_relative_eq!(dot, 32.0);
+        }
+        {
+        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Col);
+        let dot = v1.dot(&v2);
+        assert_relative_eq!(dot, 32.0);
+        }
+    }
+
+    #[test]
+    fn test_normalize()
+    {
+        {
+        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+        let norm = v.norm();
+        let normalized = v.normalize();
+        assert_relative_eq!(normalized[0], 1.0 / norm);
+        assert_relative_eq!(normalized[1], 2.0 / norm);
+        assert_relative_eq!(normalized[2], 3.0 / norm);
+        }
+        {
+        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+        let norm = v.norm();
+        let normalized = v.normalize();
+        assert_relative_eq!(normalized[0], 1.0 / norm);
+        assert_relative_eq!(normalized[1], 2.0 / norm);
+        assert_relative_eq!(normalized[2], 3.0 / norm);
+        }
+    }
+
+    #[test]
+    fn test_cross()
+    {
+        {
+        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Row);
+        let cross = v1.cross(&v2);
+        assert_relative_eq!(cross[0], -3.0);
+        assert_relative_eq!(cross[1], 6.0);
+        assert_relative_eq!(cross[2], -3.0);
+        }
+    {
+        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Col);
+        let cross = v1.cross(&v2);
+        assert_relative_eq!(cross[0], -3.0);
+        assert_relative_eq!(cross[1], 6.0);
+        assert_relative_eq!(cross[2], -3.0);
+        }
+    }
+
+    #[test]
+    fn test_angle() {
+        {
+        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 0.0, 0.0], 3, VecType::Row);
+        let v2 = DVector::<f64>::from_slice_vec(&[0.0, 1.0, 0.0], 3, VecType::Row);
+        let angle1 = v1.angle(&v2);
+        assert_relative_eq!(angle1, std::f64::consts::FRAC_PI_2);
+        let angle2 = v2.angle(&v1);
+        assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
+        }
+    }
+}

--- a/tests/vector_ops.rs
+++ b/tests/vector_ops.rs
@@ -2,13 +2,11 @@
 #![allow(incomplete_features)]
 #![feature(impl_trait_in_assoc_type)]
 
-
-mod scvector_tests 
+mod scvector_tests
 {
     use approx::assert_relative_eq;
     use topohedral_linalg::scvector::SCVector;
-    use topohedral_linalg::{VectorOps, FloatVectorOps};
-
+    use topohedral_linalg::{FloatVectorOps, VectorOps};
 
     #[test]
     fn test_norm()
@@ -50,7 +48,8 @@ mod scvector_tests
     }
 
     #[test]
-    fn test_angle() {
+    fn test_angle()
+    {
         let v1 = SCVector::<f64, 3>::from_col_slice(&[1.0, 0.0, 0.0]);
         let v2 = SCVector::<f64, 3>::from_col_slice(&[0.0, 1.0, 0.0]);
         let angle1 = v1.angle(&v2);
@@ -58,15 +57,14 @@ mod scvector_tests
         let angle2 = v2.angle(&v1);
         assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
     }
-
 }
 
-mod srvector_tests 
+mod srvector_tests
 {
 
     use approx::assert_relative_eq;
     use topohedral_linalg::srvector::SRVector;
-    use topohedral_linalg::{VectorOps, FloatVectorOps};
+    use topohedral_linalg::{FloatVectorOps, VectorOps};
 
     #[test]
     fn test_norm()
@@ -108,7 +106,8 @@ mod srvector_tests
     }
 
     #[test]
-    fn test_angle() {
+    fn test_angle()
+    {
         let v1 = SRVector::<f64, 3>::from_row_slice(&[1.0, 0.0, 0.0]);
         let v2 = SRVector::<f64, 3>::from_row_slice(&[0.0, 1.0, 0.0]);
         let angle1 = v1.angle(&v2);
@@ -117,24 +116,24 @@ mod srvector_tests
         assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
     }
 }
-mod dvector_tests 
+mod dvector_tests
 {
     use approx::assert_relative_eq;
     use topohedral_linalg::dvector::{DVector, VecType};
-    use topohedral_linalg::{VectorOps, FloatVectorOps};
+    use topohedral_linalg::{FloatVectorOps, VectorOps};
 
     #[test]
     fn test_norm()
     {
         {
-        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
-        let norm = v.norm();
-        assert_relative_eq!(norm, 14.0);
+            let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+            let norm = v.norm();
+            assert_relative_eq!(norm, 14.0);
         }
         {
-        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
-        let norm = v.norm();
-        assert_relative_eq!(norm, 14.0);
+            let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+            let norm = v.norm();
+            assert_relative_eq!(norm, 14.0);
         }
     }
 
@@ -142,16 +141,16 @@ mod dvector_tests
     fn test_dot()
     {
         {
-        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
-        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Row);
-        let dot = v1.dot(&v2);
-        assert_relative_eq!(dot, 32.0);
+            let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+            let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Row);
+            let dot = v1.dot(&v2);
+            assert_relative_eq!(dot, 32.0);
         }
         {
-        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
-        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Col);
-        let dot = v1.dot(&v2);
-        assert_relative_eq!(dot, 32.0);
+            let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+            let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Col);
+            let dot = v1.dot(&v2);
+            assert_relative_eq!(dot, 32.0);
         }
     }
 
@@ -159,20 +158,20 @@ mod dvector_tests
     fn test_normalize()
     {
         {
-        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
-        let norm = v.norm();
-        let normalized = v.normalize();
-        assert_relative_eq!(normalized[0], 1.0 / norm);
-        assert_relative_eq!(normalized[1], 2.0 / norm);
-        assert_relative_eq!(normalized[2], 3.0 / norm);
+            let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+            let norm = v.norm();
+            let normalized = v.normalize();
+            assert_relative_eq!(normalized[0], 1.0 / norm);
+            assert_relative_eq!(normalized[1], 2.0 / norm);
+            assert_relative_eq!(normalized[2], 3.0 / norm);
         }
         {
-        let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
-        let norm = v.norm();
-        let normalized = v.normalize();
-        assert_relative_eq!(normalized[0], 1.0 / norm);
-        assert_relative_eq!(normalized[1], 2.0 / norm);
-        assert_relative_eq!(normalized[2], 3.0 / norm);
+            let v = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+            let norm = v.norm();
+            let normalized = v.normalize();
+            assert_relative_eq!(normalized[0], 1.0 / norm);
+            assert_relative_eq!(normalized[1], 2.0 / norm);
+            assert_relative_eq!(normalized[2], 3.0 / norm);
         }
     }
 
@@ -180,32 +179,33 @@ mod dvector_tests
     fn test_cross()
     {
         {
-        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
-        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Row);
-        let cross = v1.cross(&v2);
-        assert_relative_eq!(cross[0], -3.0);
-        assert_relative_eq!(cross[1], 6.0);
-        assert_relative_eq!(cross[2], -3.0);
+            let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Row);
+            let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Row);
+            let cross = v1.cross(&v2);
+            assert_relative_eq!(cross[0], -3.0);
+            assert_relative_eq!(cross[1], 6.0);
+            assert_relative_eq!(cross[2], -3.0);
         }
-    {
-        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
-        let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Col);
-        let cross = v1.cross(&v2);
-        assert_relative_eq!(cross[0], -3.0);
-        assert_relative_eq!(cross[1], 6.0);
-        assert_relative_eq!(cross[2], -3.0);
+        {
+            let v1 = DVector::<f64>::from_slice_vec(&[1.0, 2.0, 3.0], 3, VecType::Col);
+            let v2 = DVector::<f64>::from_slice_vec(&[4.0, 5.0, 6.0], 3, VecType::Col);
+            let cross = v1.cross(&v2);
+            assert_relative_eq!(cross[0], -3.0);
+            assert_relative_eq!(cross[1], 6.0);
+            assert_relative_eq!(cross[2], -3.0);
         }
     }
 
     #[test]
-    fn test_angle() {
+    fn test_angle()
+    {
         {
-        let v1 = DVector::<f64>::from_slice_vec(&[1.0, 0.0, 0.0], 3, VecType::Row);
-        let v2 = DVector::<f64>::from_slice_vec(&[0.0, 1.0, 0.0], 3, VecType::Row);
-        let angle1 = v1.angle(&v2);
-        assert_relative_eq!(angle1, std::f64::consts::FRAC_PI_2);
-        let angle2 = v2.angle(&v1);
-        assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
+            let v1 = DVector::<f64>::from_slice_vec(&[1.0, 0.0, 0.0], 3, VecType::Row);
+            let v2 = DVector::<f64>::from_slice_vec(&[0.0, 1.0, 0.0], 3, VecType::Row);
+            let angle1 = v1.angle(&v2);
+            assert_relative_eq!(angle1, std::f64::consts::FRAC_PI_2);
+            let angle2 = v2.angle(&v1);
+            assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
         }
     }
 }

--- a/tests/vector_ops.rs
+++ b/tests/vector_ops.rs
@@ -1,0 +1,62 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+#![feature(impl_trait_in_assoc_type)]
+
+
+mod scvector_tests 
+{
+    use approx::assert_relative_eq;
+    use topohedral_linalg::scvector::SCVector;
+    use topohedral_linalg::{VectorOps, FloatVectorOps};
+
+
+    #[test]
+    fn test_norm()
+    {
+        let v = SCVector::<f64, 3>::from_col_slice(&[1.0, 2.0, 3.0]);
+        let norm = v.norm();
+        assert_relative_eq!(norm, 14.0);
+    }
+
+    #[test]
+    fn test_dot()
+    {
+        let v1 = SCVector::<f64, 3>::from_col_slice(&[1.0, 2.0, 3.0]);
+        let v2 = SCVector::<f64, 3>::from_col_slice(&[4.0, 5.0, 6.0]);
+        let dot = v1.dot(&v2);
+        assert_relative_eq!(dot, 32.0);
+    }
+
+    #[test]
+    fn test_normalize()
+    {
+        let v = SCVector::<f64, 3>::from_col_slice(&[1.0, 2.0, 3.0]);
+        let norm = v.norm();
+        let normalized = v.normalize();
+        assert_relative_eq!(normalized[0], 1.0 / norm);
+        assert_relative_eq!(normalized[1], 2.0 / norm);
+        assert_relative_eq!(normalized[2], 3.0 / norm);
+    }
+
+    #[test]
+    fn test_cross()
+    {
+        let v1 = SCVector::<f64, 3>::from_col_slice(&[1.0, 2.0, 3.0]);
+        let v2 = SCVector::<f64, 3>::from_col_slice(&[4.0, 5.0, 6.0]);
+        let cross = v1.cross(&v2);
+        assert_relative_eq!(cross[0], -3.0);
+        assert_relative_eq!(cross[1], 6.0);
+        assert_relative_eq!(cross[2], -3.0);
+    }
+
+    #[test]
+    fn test_angle() {
+        let v1 = SCVector::<f64, 3>::from_col_slice(&[1.0, 0.0, 0.0]);
+        let v2 = SCVector::<f64, 3>::from_col_slice(&[0.0, 1.0, 0.0]);
+        let angle1 = v1.angle(&v2);
+        assert_relative_eq!(angle1, std::f64::consts::FRAC_PI_2);
+        let angle2 = v2.angle(&v1);
+        assert_relative_eq!(angle2, std::f64::consts::FRAC_PI_2);
+    }
+
+}


### PR DESCRIPTION
Adds all vector types derived from the matrix types. Impelement Vector-specific functionality.

Closes COR-47